### PR TITLE
Fix readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-![Parallel-Mengene Logo](https://img.shields.io/badge/Parallel-Mengene-blue?style=for-the-badge&logo=rust)
+![Parallel-Mengene](https://img.shields.io/badge/Parallel--Mengene-blue?style=for-the-badge)
 ![Version](https://img.shields.io/badge/version-1.0.0-green?style=for-the-badge)
 ![License](https://img.shields.io/badge/license-MIT%20%7C%20Apache%202.0-blue?style=for-the-badge)
 ![Rust](https://img.shields.io/badge/rust-1.75%2B-orange?style=for-the-badge&logo=rust)
 
 **High-performance parallel file compression tool** - Squeeze it parallel! 🚀
 
-[![Fast CI/CD Pipeline](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml/badge.svg)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml)
-[![Security Audit](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml)
-[![Code Quality](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml)
-[![Self-Hosted Runner](https://img.shields.io/badge/runner-self--hosted-green?style=flat-square)](https://github.com/hocestnonsatis/parallel-mengene/actions)
+[![CI/CD Pipeline](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml/badge.svg)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/ci.yml)
+[![Security Audit](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/security.yml/badge.svg)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/security.yml)
+[![Code Quality](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/quality.yml/badge.svg)](https://github.com/hocestnonsatis/parallel-mengene/actions/workflows/quality.yml)
+[![Self-Hosted Runner](https://img.shields.io/badge/runner-self--hosted-brightgreen?style=flat-square&logo=github)](https://github.com/hocestnonsatis/parallel-mengene/actions)
 
 </div>
 


### PR DESCRIPTION
## 📝 Description

This PR addresses inconsistencies and inaccuracies in the badges displayed in the `README.md` file.

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📚 Documentation update

## 🧪 Testing

- [x] Manual testing completed
  *   Verified that all badges render correctly and link to the appropriate resources in the `README.md` file.

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## 🚀 Performance Impact

- [x] No performance impact

## 🔗 Related Issues

<!-- Link to any related issues -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## 📝 Additional Notes

Specific changes include:
*   Removed an invalid `logo` parameter from the `Parallel-Mengene` badge.
*   Corrected CI/CD badges to point to their respective workflow files (`ci.yml`, `security.yml`, `quality.yml`).
*   Enhanced the `Self-Hosted Runner` badge's visual style by changing its color and adding a GitHub logo.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd97f88c-c1dd-4753-ae69-4d1596d0ed64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd97f88c-c1dd-4753-ae69-4d1596d0ed64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

